### PR TITLE
Claims for everyone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
   - gpg2 --version
   - echo $PATH
   - which gpg2
-  - tox -e $TESTENV --recreate -- tests/
+  - tox -e $TESTENV --recreate -- tests/ --with-plugins
 
 #notifications:
 #  irc:

--- a/muacryptcc/plugin.py
+++ b/muacryptcc/plugin.py
@@ -51,11 +51,12 @@ class CCAccount(object):
         recipients = get_target_emailadr(dec_msg)
         # TODO: handle everyone.
         for recipient in recipients:
+            pagh = addr2pagh[recipient]
             value = self.read_claim_from(peers_chain, recipient)
             if value:
                 # for now we can only read claims about ourselves...
                 # so if we get a value it must be our head imprint.
-                assert value == self.head_imprint
+                assert value == bytes2ascii(pagh.keydata)
 
     @hookimpl
     def process_before_encryption(self, sender_addr, sender_keyhandle,
@@ -65,12 +66,10 @@ class CCAccount(object):
             logging.error("no recipients found.\n")
         for recipient in recipients:
             key = recipient
-            value = self.addr2root_hash.get(recipient)
+            value = bytes2ascii(recipient2keydata.get(recipient))
             peers_pk = self.addr2pk.get(recipient)
-            if peers_pk:
+            if value:
                 self.add_claim(claim=(key, value), access_pk=peers_pk)
-            else:
-                logging.warn(recipient + " not found")
         self.commit_to_chain()
         payload_msg["GossipClaims"] = self.head_imprint
         # TODO: what do we do with dict stores?

--- a/muacryptcc/plugin.py
+++ b/muacryptcc/plugin.py
@@ -49,7 +49,6 @@ class CCAccount(object):
         self.addr2root_hash[sender] = root_hash
         self.addr2pk[sender] = peers_pk
         recipients = get_target_emailadr(dec_msg)
-        # TODO: handle everyone.
         for recipient in recipients:
             pagh = addr2pagh[recipient]
             value = self.read_claim_from(peers_chain, recipient)
@@ -64,12 +63,13 @@ class CCAccount(object):
         recipients = recipient2keydata.keys()
         if not recipients:
             logging.error("no recipients found.\n")
+
         for recipient in recipients:
-            key = recipient
-            value = bytes2ascii(recipient2keydata.get(recipient))
-            peers_pk = self.addr2pk.get(recipient)
-            if value:
-                self.add_claim(claim=(key, value), access_pk=peers_pk)
+            claim = recipient, bytes2ascii(recipient2keydata.get(recipient))
+            for reader in recipients:
+                pk = self.addr2pk.get(reader)
+                self.add_claim(claim, access_pk=pk)
+
         self.commit_to_chain()
         payload_msg["GossipClaims"] = self.head_imprint
         # TODO: what do we do with dict stores?

--- a/muacryptcc/plugin.py
+++ b/muacryptcc/plugin.py
@@ -3,12 +3,11 @@ from __future__ import print_function, unicode_literals
 import logging
 import os
 import json
-import binascii
 import pluggy
 from hippiehug import Chain
 from claimchain import State, View
 from claimchain.crypto.params import LocalParams
-from claimchain.utils import pet2ascii
+from claimchain.utils import pet2ascii, bytes2ascii, ascii2bytes
 from muacrypt.mime import parse_email_addr, get_target_emailadr
 from .filestore import FileStore
 
@@ -41,7 +40,7 @@ class CCAccount(object):
     def process_incoming_gossip(self, addr2pagh, account_key, dec_msg):
         root_hash = dec_msg["GossipClaims"]
         store = FileStore(dec_msg["ChainStore"])
-        peers_chain = Chain(store, root_hash=binascii.unhexlify(root_hash))
+        peers_chain = Chain(store, root_hash=ascii2bytes(root_hash))
         assert peers_chain
         view = View(peers_chain)
         peers_pk = view.params.dh.pk
@@ -117,7 +116,7 @@ class CCAccount(object):
 
     @property
     def head_imprint(self):
-        return binascii.hexlify(self.head)
+        return bytes2ascii(self.head)
 
     def commit_to_chain(self):
         chain = self._get_current_chain()

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -4,6 +4,7 @@
 from __future__ import unicode_literals
 import os
 from test_muacrypt.test_account import gen_ac_mail_msg
+from muacrypt.account import Account
 from muacryptcc.plugin import CCAccount
 from muacryptcc.filestore import FileStore
 from claimchain.utils import bytes2ascii
@@ -12,47 +13,65 @@ from claimchain.utils import bytes2ascii
 def test_no_claim_headers_in_cleartext_mail(account_maker):
     acc1, acc2 = account_maker(), account_maker()
 
-    msg = send_and_process_mail(acc1, acc2)
+    msg = send_mail(acc1, acc2)
     assert not msg['GossipClaims']
     assert not msg['ClaimStore']
 
 
 def test_claim_headers_in_encrypted_mail(account_maker):
     acc1, acc2 = account_maker(), account_maker()
-    send_and_process_mail(acc1, acc2)
+    send_mail(acc1, acc2)
 
-    dec_msg = send_and_process_encrypted_mail(acc2, acc1)[1].dec_msg
-    account = get_cc_account(dec_msg['ChainStore'])
-    assert dec_msg['GossipClaims'] == account.head_imprint
-    assert account.has_readable_claim(acc1.addr)
+    dec_msg = send_encrypted_mail(acc2, acc1)[1].dec_msg
+    cc2 = get_cc_account(dec_msg['ChainStore'])
+    assert dec_msg['GossipClaims'] == cc2.head_imprint
+    assert cc2.has_readable_claim(acc1.addr)
 
 
-def test_claim_headers_in_encrypted_mail(account_maker):
+def test_claims_contain_keys(account_maker):
     acc1, acc2 = account_maker(), account_maker()
-    send_and_process_mail(acc1, acc2)
+    send_mail(acc1, acc2)
 
-    cc2, ac2 = get_cc_and_ac(send_and_process_encrypted_mail(acc2, acc1))
-    cc1, ac1 = get_cc_and_ac(send_and_process_encrypted_mail(acc1, acc2))
+    cc2, ac2 = get_cc_and_ac(send_encrypted_mail(acc2, acc1))
+    cc1, ac1 = get_cc_and_ac(send_encrypted_mail(acc1, acc2))
 
     assert cc1.read_claim_as(cc2, acc2.addr) == bytes2ascii(ac2.keydata)
 
 
+def test_gossip_claims(account_maker):
+    acc1, acc2, acc3 = account_maker(), account_maker(), account_maker()
+    send_mail(acc1, acc2)
+    send_mail(acc1, acc3)
+
+    cc2, ac2 = get_cc_and_ac(send_encrypted_mail(acc2, acc1))
+    cc3, ac3 = get_cc_and_ac(send_encrypted_mail(acc3, acc1))
+    cc1, ac1 = get_cc_and_ac(send_encrypted_mail(acc1, [acc2, acc3]))
+
+    assert cc1.read_claim_as(cc2, acc3.addr) == bytes2ascii(ac3.keydata)
+
+
 # send a mail from acc1 with autocrypt key to acc2
-def send_and_process_mail(acc1, acc2):
+def send_mail(acc1, acc2):
     msg = gen_ac_mail_msg(acc1, acc2)
     acc2.process_incoming(msg)
     return msg
 
 
-def send_and_process_encrypted_mail(acc1, acc2):
-    """Send an encrypted mail from acc1 to acc2
+def send_encrypted_mail(sender, recipients):
+    """Send an encrypted mail from sender to recipients
        Decrypt and process it.
        Returns the result of processing the Autocrypt header
        and the decryption result.
     """
-    msg = gen_ac_mail_msg(acc1, acc2, payload="hello ä umlaut", charset="utf8")
-    enc_msg = acc1.encrypt_mime(msg, [acc2.addr]).enc_msg
-    return acc2.process_incoming(enc_msg), acc2.decrypt_mime(enc_msg)
+    if isinstance(recipients, Account):
+        recipients = [recipients]
+    msg = gen_ac_mail_msg(sender, recipients, payload="hello ä umlaut", charset="utf8")
+    enc_msg = sender.encrypt_mime(msg, [r.addr for r in recipients]).enc_msg
+    for rec in recipients:
+        processed = rec.process_incoming(enc_msg)
+        decrypted = rec.decrypt_mime(enc_msg)
+    return processed, decrypted
+
 
 def get_cc_and_ac(pair):
     """

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -2,25 +2,52 @@
 # vim:ts=4:sw=4:expandtab
 
 from __future__ import unicode_literals
+import os
 from test_muacrypt.test_account import gen_ac_mail_msg
+from muacryptcc.plugin import CCAccount
+from muacryptcc.filestore import FileStore
 
 
-def test_encrypt_decrypt_mime_text_plain(account_maker):
+def test_no_claim_headers_in_cleartext_mail(account_maker):
     acc1, acc2 = account_maker(), account_maker()
 
-    # send a mail from addr1 with autocrypt key to addr2
+    msg = send_and_process_mail(acc1, acc2)
+    assert not msg['GossipClaims']
+    assert not msg['ClaimStore']
+
+
+def test_claim_headers_in_encrypted_mail(account_maker):
+    acc1, acc2 = account_maker(), account_maker()
+
+    send_and_process_mail(acc1, acc2)
+    dec_msg = send_and_process_encrypted_mail(acc2, acc1).dec_msg
+    account = get_cc_account(dec_msg['ChainStore'])
+    assert dec_msg['GossipClaims'] == account.head_imprint
+
+
+# send a mail from acc1 with autocrypt key to acc2
+def send_and_process_mail(acc1, acc2):
     msg = gen_ac_mail_msg(acc1, acc2)
-    r = acc2.process_incoming(msg)
-    assert r.peerstate.addr == acc1.addr
+    acc2.process_incoming(msg)
+    return msg
 
-    # send an encrypted mail from addr2 to addr1
-    msg2 = gen_ac_mail_msg(acc2, acc1, payload="hello ä umlaut", charset="utf8")
-    r = acc2.encrypt_mime(msg2, [acc1.addr])
-    acc1.process_incoming(r.enc_msg)
 
-    # decrypt the incoming mail
-    r = acc1.decrypt_mime(r.enc_msg)
-    dec = r.dec_msg
-    assert dec.get_content_type() == "text/plain"
-    assert dec.get_payload() == msg2.get_payload()
-    assert dec.get_payload(decode=True) == msg2.get_payload(decode=True)
+def send_and_process_encrypted_mail(acc1, acc2):
+    """Send an encrypted mail from acc1 to acc2
+       Decrypt and process it.
+       Returns the decryption result with enc_msg and dec_msg.
+    """
+    msg = gen_ac_mail_msg(acc1, acc2, payload="hello ä umlaut", charset="utf8")
+    enc_msg = acc1.encrypt_mime(msg, [acc2.addr]).enc_msg
+    acc2.process_incoming(enc_msg)
+    return acc2.decrypt_mime(enc_msg)
+
+
+def get_cc_account(store_dir):
+    """ Retrieve a ClaimChain account based from the give store_dir.
+    """
+    assert os.path.exists(store_dir)
+    store = FileStore(store_dir)
+    cc_dir = os.path.join(store_dir, '..')
+    assert os.path.exists(cc_dir)
+    return CCAccount(cc_dir, store)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -6,6 +6,7 @@ import os
 from test_muacrypt.test_account import gen_ac_mail_msg
 from muacryptcc.plugin import CCAccount
 from muacryptcc.filestore import FileStore
+from claimchain.utils import bytes2ascii
 
 
 def test_no_claim_headers_in_cleartext_mail(account_maker):
@@ -18,12 +19,28 @@ def test_no_claim_headers_in_cleartext_mail(account_maker):
 
 def test_claim_headers_in_encrypted_mail(account_maker):
     acc1, acc2 = account_maker(), account_maker()
-
     send_and_process_mail(acc1, acc2)
-    dec_msg = send_and_process_encrypted_mail(acc2, acc1).dec_msg
+
+    dec_msg = send_and_process_encrypted_mail(acc2, acc1)[1].dec_msg
     account = get_cc_account(dec_msg['ChainStore'])
     assert dec_msg['GossipClaims'] == account.head_imprint
     assert account.has_readable_claim(acc1.addr)
+
+
+def test_claim_headers_in_encrypted_mail(account_maker):
+    acc1, acc2 = account_maker(), account_maker()
+    send_and_process_mail(acc1, acc2)
+
+    r, mail = send_and_process_encrypted_mail(acc2, acc1)
+    cc2 = get_cc_account(mail.dec_msg['ChainStore'])
+    ac2 = r.pah
+
+    r, mail = send_and_process_encrypted_mail(acc1, acc2)
+    cc1 = get_cc_account(mail.dec_msg['ChainStore'])
+    ac1 = r.pah
+
+    assert mail.dec_msg['GossipClaims'] == cc1.head_imprint
+    assert cc1.read_claim_as(cc2, acc2.addr) == bytes2ascii(ac2.keydata)
 
 
 # send a mail from acc1 with autocrypt key to acc2
@@ -40,8 +57,7 @@ def send_and_process_encrypted_mail(acc1, acc2):
     """
     msg = gen_ac_mail_msg(acc1, acc2, payload="hello ä umlaut", charset="utf8")
     enc_msg = acc1.encrypt_mime(msg, [acc2.addr]).enc_msg
-    acc2.process_incoming(enc_msg)
-    return acc2.decrypt_mime(enc_msg)
+    return acc2.process_incoming(enc_msg), acc2.decrypt_mime(enc_msg)
 
 
 def get_cc_account(store_dir):

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -23,6 +23,7 @@ def test_claim_headers_in_encrypted_mail(account_maker):
     dec_msg = send_and_process_encrypted_mail(acc2, acc1).dec_msg
     account = get_cc_account(dec_msg['ChainStore'])
     assert dec_msg['GossipClaims'] == account.head_imprint
+    assert account.has_readable_claim(acc1.addr)
 
 
 # send a mail from acc1 with autocrypt key to acc2


### PR DESCRIPTION
Add claims for all recipients, readable by all of them in gossip mails.

The content of the claims so far is the entire public OpenPGP key. This is not what we want yet. We probably want the fingerprint and cc head imprint and cc chain source instead.