### PR TITLE
dicts as claim content

### DIFF
--- a/muacryptcc/plugin.py
+++ b/muacryptcc/plugin.py
@@ -51,7 +51,7 @@ class CCAccount(object):
         recipients = get_target_emailadr(dec_msg)
         for recipient in recipients:
             pagh = addr2pagh[recipient]
-            value = self.read_claim_from(peers_chain, recipient)
+            value = self.read_claim(recipient, chain=peers_chain)
             if value:
                 # for now we can only read claims about ourselves...
                 # so if we get a value it must be our head imprint.
@@ -132,12 +132,6 @@ class CCAccount(object):
                 return View(chain)[claimkey.encode('utf-8')].decode('utf-8')
         except (KeyError, ValueError):
             return None
-
-    def read_claim_as(self, other, claimkey):
-        return self.read_claim(claimkey, reader=other)
-
-    def read_claim_from(self, chain, claimkey):
-        return self.read_claim(claimkey, chain=chain)
 
     def add_claim(self, claim, access_pk=None):
         key, value = claim[0].encode('utf-8'), claim[1].encode('utf-8')

--- a/muacryptcc/plugin.py
+++ b/muacryptcc/plugin.py
@@ -129,12 +129,14 @@ class CCAccount(object):
             reader = self
         try:
             with reader.params.as_default():
-                return View(chain)[claimkey.encode('utf-8')].decode('utf-8')
+                value = View(chain)[claimkey.encode('utf-8')]
+                return json.loads(value.decode('utf-8'))
         except (KeyError, ValueError):
             return None
 
     def add_claim(self, claim, access_pk=None):
-        key, value = claim[0].encode('utf-8'), claim[1].encode('utf-8')
+        key = claim[0].encode('utf-8')
+        value = json.dumps(claim[1]).encode('utf-8')
         assert isinstance(key, bytes)
         assert isinstance(value, bytes)
         self.state[key] = value

--- a/muacryptcc/plugin.py
+++ b/muacryptcc/plugin.py
@@ -55,7 +55,7 @@ class CCAccount(object):
             if value:
                 # for now we can only read claims about ourselves...
                 # so if we get a value it must be our head imprint.
-                assert value == bytes2ascii(pagh.keydata)
+                assert value['key'] == bytes2ascii(pagh.keydata)
 
     @hookimpl
     def process_before_encryption(self, sender_addr, sender_keyhandle,
@@ -65,10 +65,13 @@ class CCAccount(object):
             logging.error("no recipients found.\n")
 
         for recipient in recipients:
-            claim = recipient, bytes2ascii(recipient2keydata.get(recipient))
+            key = recipient
+            value = dict(
+                key=bytes2ascii(recipient2keydata.get(recipient))
+            )
             for reader in recipients:
                 pk = self.addr2pk.get(reader)
-                self.add_claim(claim, access_pk=pk)
+                self.add_claim((key, value), access_pk=pk)
 
         self.commit_to_chain()
         payload_msg["GossipClaims"] = self.head_imprint

--- a/muacryptcc/plugin.py
+++ b/muacryptcc/plugin.py
@@ -139,12 +139,6 @@ class CCAccount(object):
     def read_claim_from(self, chain, claimkey):
         return self.read_claim(claimkey, chain=chain)
 
-    def has_readable_claim(self, claimkey):
-        return self.has_readable_claim_for(self, claimkey)
-
-    def has_readable_claim_for(self, other, claimkey):
-        return self.read_claim_as(other, claimkey) is not None
-
     def add_claim(self, claim, access_pk=None):
         key, value = claim[0].encode('utf-8'), claim[1].encode('utf-8')
         assert isinstance(key, bytes)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -35,7 +35,7 @@ def test_claims_contain_keys(account_maker):
     cc2, ac2 = get_cc_and_ac(send_encrypted_mail(acc2, acc1))
     cc1, ac1 = get_cc_and_ac(send_encrypted_mail(acc1, acc2))
 
-    assert cc1.read_claim_as(cc2, acc2.addr) == bytes2ascii(ac2.keydata)
+    assert cc1.read_claim(acc2.addr, reader=cc2) == bytes2ascii(ac2.keydata)
 
 
 def test_gossip_claims(account_maker):
@@ -47,7 +47,7 @@ def test_gossip_claims(account_maker):
     cc3, ac3 = get_cc_and_ac(send_encrypted_mail(acc3, acc1))
     cc1, ac1 = get_cc_and_ac(send_encrypted_mail(acc1, [acc2, acc3]))
 
-    assert cc1.read_claim_as(cc2, acc3.addr) == bytes2ascii(ac3.keydata)
+    assert cc1.read_claim(acc3.addr, reader=cc2) == bytes2ascii(ac3.keydata)
 
 
 # send a mail from acc1 with autocrypt key to acc2

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -35,7 +35,8 @@ def test_claims_contain_keys(account_maker):
     cc2, ac2 = get_cc_and_ac(send_encrypted_mail(acc2, acc1))
     cc1, ac1 = get_cc_and_ac(send_encrypted_mail(acc1, acc2))
 
-    assert cc1.read_claim(acc2.addr, reader=cc2) == bytes2ascii(ac2.keydata)
+    data = cc1.read_claim(acc2.addr, reader=cc2)
+    assert data['key'] == bytes2ascii(ac2.keydata)
 
 
 def test_gossip_claims(account_maker):
@@ -47,7 +48,8 @@ def test_gossip_claims(account_maker):
     cc3, ac3 = get_cc_and_ac(send_encrypted_mail(acc3, acc1))
     cc1, ac1 = get_cc_and_ac(send_encrypted_mail(acc1, [acc2, acc3]))
 
-    assert cc1.read_claim(acc3.addr, reader=cc2) == bytes2ascii(ac3.keydata)
+    data = cc1.read_claim(acc3.addr, reader=cc2)
+    assert data['key'] == bytes2ascii(ac3.keydata)
 
 
 # send a mail from acc1 with autocrypt key to acc2

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -25,7 +25,7 @@ def test_claim_headers_in_encrypted_mail(account_maker):
     dec_msg = send_encrypted_mail(acc2, acc1)[1].dec_msg
     cc2 = get_cc_account(dec_msg['ChainStore'])
     assert dec_msg['GossipClaims'] == cc2.head_imprint
-    assert cc2.has_readable_claim(acc1.addr)
+    assert cc2.read_claim(acc1.addr)
 
 
 def test_claims_contain_keys(account_maker):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -47,6 +47,6 @@ def test_add_claim_with_access_control(make_account):
 
     cc_alice.add_claim(claim=("bob_feet", "4"), access_pk=bob_pk)
     cc_alice.commit_to_chain()
-    assert cc_alice.read_claim_as(cc_bob, "bob_feet")
-    assert cc_alice.read_claim_as(cc_alice, "bob_feet")
-    assert not cc_alice.read_claim_as(cc_bob, "bob_hair")
+    assert cc_alice.read_claim("bob_feet", reader=cc_bob)
+    assert cc_alice.read_claim("bob_feet", reader=cc_alice)
+    assert not cc_alice.read_claim("bob_hair", reader=cc_bob)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -34,19 +34,19 @@ def test_account_can_be_propertly_instanted_from_store(make_account):
 
 def test_add_claim_with_access_control(make_account):
     cc_alice = make_account("alice")
-    cc_bob = make_account("bob")
+    cc_bob = make_account("bo")
     bob_pk = cc_bob.get_public_key()
 
-    assert not cc_alice.has_readable_claim(b"bob_hair")
+    assert not cc_alice.has_readable_claim("bob_hair")
 
     cc_alice.add_claim(
-        claim=(b"bob_hair", b"black")
+        claim=("bob_hair", "black")
     )
     cc_alice.commit_to_chain()
-    assert cc_alice.has_readable_claim(b"bob_hair")
+    assert cc_alice.has_readable_claim("bob_hair")
 
-    cc_alice.add_claim(claim=(b"bob_feet", b"4"), access_pk=bob_pk)
+    cc_alice.add_claim(claim=("bob_feet", "4"), access_pk=bob_pk)
     cc_alice.commit_to_chain()
-    assert cc_alice.has_readable_claim_for(cc_bob, b"bob_feet")
-    assert cc_alice.has_readable_claim_for(cc_alice, b"bob_feet")
-    assert not cc_alice.has_readable_claim_for(cc_bob, b"bob_hair")
+    assert cc_alice.has_readable_claim_for(cc_bob, "bob_feet")
+    assert cc_alice.has_readable_claim_for(cc_alice, "bob_feet")
+    assert not cc_alice.has_readable_claim_for(cc_bob, "bob_hair")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -37,16 +37,16 @@ def test_add_claim_with_access_control(make_account):
     cc_bob = make_account("bo")
     bob_pk = cc_bob.get_public_key()
 
-    assert not cc_alice.has_readable_claim("bob_hair")
+    assert not cc_alice.read_claim("bob_hair")
 
     cc_alice.add_claim(
         claim=("bob_hair", "black")
     )
     cc_alice.commit_to_chain()
-    assert cc_alice.has_readable_claim("bob_hair")
+    assert cc_alice.read_claim("bob_hair")
 
     cc_alice.add_claim(claim=("bob_feet", "4"), access_pk=bob_pk)
     cc_alice.commit_to_chain()
-    assert cc_alice.has_readable_claim_for(cc_bob, "bob_feet")
-    assert cc_alice.has_readable_claim_for(cc_alice, "bob_feet")
-    assert not cc_alice.has_readable_claim_for(cc_bob, "bob_hair")
+    assert cc_alice.read_claim_as(cc_bob, "bob_feet")
+    assert cc_alice.read_claim_as(cc_alice, "bob_feet")
+    assert not cc_alice.read_claim_as(cc_bob, "bob_hair")


### PR DESCRIPTION
First step towards #7.

Also simplified the cc Account api a bunch by turning `has_readable_claim`, `has_readable_claim_for` and `read_claim_from`, `read_claim_as` into `read_claim(key, chain=chain, reader=reader)`