### PR TITLE
first steps towards a sync to cchttpserver

### DIFF
--- a/muacryptcc/commands.py
+++ b/muacryptcc/commands.py
@@ -24,7 +24,11 @@ def cc_status(ctx, account_name):
     for name in names:
         cc_account = get_cc_account(ctx, name)
         assert cc_account
-        click.echo("found account %r, XXX add info" % name)
+        click.echo("found account %r" % str(name))
+        click.echo("Head Imprint: %r" % cc_account.head_imprint)
+        click.echo("Remote Url: %r" % cc_account.store.url)
+        click.echo("CC data stored in %r" % cc_account.accountdir)
+        click.echo("%r entries." % len(cc_account.store))
 
 
 @mycommand("cc-send")

--- a/muacryptcc/filestore.py
+++ b/muacryptcc/filestore.py
@@ -1,4 +1,5 @@
 import os
+import requests
 
 from base58 import b58encode, b58decode
 import msgpack
@@ -15,6 +16,14 @@ def basename2key(basename):
     if not isinstance(basename, bytes):
         basename = basename.encode("ascii")
     return b58decode(basename)
+
+
+def value_from_data(bdata):
+    branch = msgpack.unpackb(bdata, ext_hook=ext_hook)
+    if isinstance(branch, bytes):
+        return Blob(branch)
+    # assert key == branch.identity()
+    return branch
 
 
 def default(obj):
@@ -46,48 +55,64 @@ def ext_hook(code, data):
 
 
 class FileStore:
-    def __init__(self, dir):
+    def __init__(self, dir, url="http://test1:password1@localhost:5000"):
         assert dir
+        # TODO: remove default and assert url
         self._dir = dir
+        self._url = url
         if not os.path.exists(dir):
             os.makedirs(dir)
 
     def __getitem__(self, key):
-        bdata = self.file_get(key)
-        branch = msgpack.unpackb(bdata, ext_hook=ext_hook)
-        if isinstance(branch, bytes):
-            return Blob(branch)
-        # assert key == branch.identity()
-        return branch
+        bn = key2basename(key)
+        bdata = self.file_get(bn)
+        return value_from_data(bdata)
 
     def __setitem__(self, key, value):
+        bn = key2basename(key)
         bdata = msgpack.packb(value, default=default)
         # assert key == value.identity()
-        self.file_set(key, bdata)
+        self.file_set(bn, bdata)
 
-    def file_set(self, key, value):
-        if not isinstance(value, bytes):
-            raise ValueError("Value must be of type bytes")
+    def send(self):
+        for bn, data in self.files():
+            r = requests.put(self._url + "/" + bn, data)
+            assert r.status_code in [200, 202]
+
+    def recv(self, key):
         bn = key2basename(key)
+        r = requests.get(self._url + "/" + bn)
+        assert r.status_code in [200, 202]
+        data = r.content
+        if not isinstance(data, bytes):
+            raise ValueError("data must be of type bytes")
         with open(os.path.join(self._dir, bn), "wb") as f:
-            f.write(value)
+            f.write(data)
+
+    def file_set(self, bn, data):
+        if not isinstance(data, bytes):
+            raise ValueError("Value must be of type bytes")
+        with open(os.path.join(self._dir, bn), "wb") as f:
+            f.write(data)
             # print("store-set {!r}={!r}".format(bn, value))
 
-    def file_get(self, key):
-        bn = key2basename(key)
+    def items(self):
+        for raw_key, raw_data in self.files():
+            yield basename2key(raw_key), value_from_data(raw_data)
+
+    def files(self):
+        try:
+            keys = os.listdir(self._dir)
+        except OSError:
+            keys = []
+        for key in keys:
+            yield key, self.file_get(key)
+
+    def file_get(self, bn):
         try:
             with open(os.path.join(self._dir, bn), "rb") as f:
                 val = f.read()
                 # print("store-get {!r} -> {!r}".format(bn, val))
             return val
         except IOError:
-            raise KeyError(key)
-
-    def items(self):
-        try:
-            encoded_keys = os.listdir(self._dir)
-        except OSError:
-            encoded_keys = []
-        for raw_key in encoded_keys:
-            key = basename2key(raw_key)
-            yield key, self[key]
+            raise KeyError(basename2key(bn))

--- a/muacryptcc/filestore.py
+++ b/muacryptcc/filestore.py
@@ -63,6 +63,9 @@ class FileStore:
         if not os.path.exists(dir):
             os.makedirs(dir)
 
+    def url(self):
+        return self._url
+
     def __getitem__(self, key):
         bn = key2basename(key)
         try:

--- a/muacryptcc/filestore.py
+++ b/muacryptcc/filestore.py
@@ -59,12 +59,9 @@ class FileStore:
         assert dir
         # TODO: remove default and assert url
         self._dir = dir
-        self._url = url
+        self.url = url
         if not os.path.exists(dir):
             os.makedirs(dir)
-
-    def url(self):
-        return self._url
 
     def __getitem__(self, key):
         bn = key2basename(key)
@@ -81,14 +78,21 @@ class FileStore:
         # assert key == value.identity()
         self._file_set(bn, bdata)
 
+    def __len__(self):
+        try:
+            keys = os.listdir(self._dir)
+        except OSError:
+            keys = []
+        return len(keys)
+
     def send(self):
         for bn, data in self.files():
-            r = requests.put(self._url + "/" + bn, data)
+            r = requests.put(self.url + "/" + bn, data)
             assert r.status_code in [200, 202]
 
     def recv(self, key):
         bn = key2basename(key)
-        r = requests.get(self._url + "/" + bn)
+        r = requests.get(self.url + "/" + bn)
         if not r.status_code in [200, 202]:
             raise KeyError(key)
         data = r.content

--- a/muacryptcc/plugin.py
+++ b/muacryptcc/plugin.py
@@ -85,7 +85,7 @@ class CCAccount(object):
         self.commit_to_chain()
         payload_msg["GossipClaims"] = self.head_imprint
         # TODO: what do we do with dict stores?
-        payload_msg["ClaimStore"] = self.store.url()
+        payload_msg["ClaimStore"] = self.store.url
 
     def init_crypto_identity(self):
         identity_file = os.path.join(self.accountdir, 'identity.json')

--- a/muacryptcc/plugin.py
+++ b/muacryptcc/plugin.py
@@ -53,7 +53,7 @@ class CCAccount(object):
     def process_incoming_gossip(self, addr2pagh, account_key, dec_msg):
         sender_addr = parse_email_addr(dec_msg["From"])
         root_hash = dec_msg["GossipClaims"]
-        store_url = dec_msg["ChainStore"]
+        store_url = dec_msg["ClaimStore"]
         if not root_hash or not store_url:
             # this peer has no CC support
             return
@@ -85,7 +85,7 @@ class CCAccount(object):
         self.commit_to_chain()
         payload_msg["GossipClaims"] = self.head_imprint
         # TODO: what do we do with dict stores?
-        payload_msg["ChainStore"] = self.store._dir
+        payload_msg["ClaimStore"] = self.store.url()
 
     def init_crypto_identity(self):
         identity_file = os.path.join(self.accountdir, 'identity.json')
@@ -127,7 +127,8 @@ class CCAccount(object):
         )))
 
     def get_chain(self, store_url, root_hash):
-        store = FileStore(store_url)
+        cache_dir = os.path.join(self.accountdir, 'cache')
+        store = FileStore(cache_dir, store_url)
         return Chain(store, root_hash=ascii2bytes(root_hash))
 
     def verify_claim(self, chain, addr, keydata, store_url='',
@@ -149,6 +150,8 @@ class CCAccount(object):
     def commit_to_chain(self):
         with self.params.as_default():
             self._head = self.state.commit(self.chain)
+        if hasattr(self.store, 'send'):
+            self.store.send()
 
     def read_claim(self, claimkey, chain=None):
         if chain is None:

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -11,7 +11,13 @@ def acmd(mycmd):
 
 def test_ccstatus(acmd):
     acmd.run_ok(["cc-status"])
-    acmd.run_ok(["cc-status", "default"])
+    acmd.run_ok(["cc-status", "default"], """
+    found account 'default'
+    Head Imprint: *
+    Remote Url: 'http://*
+    CC data stored in *account/default/muacryptcc*
+    1 entries.
+    """)
 
 
 def test_ccsync(acmd):

--- a/tests/test_filestore.py
+++ b/tests/test_filestore.py
@@ -18,3 +18,13 @@ def test_file_store(tmpdir):
         store.file_set(b'key', 32)
     store2 = FileStore(str(tmpdir))
     assert b'value' == store2.file_get(b'key')
+
+
+def test_file_store_sync(tmpdir):
+    key = b'key has to be longer then a minimum length'
+    source = FileStore(str(tmpdir) + '-source')
+    source[key] = b'value'
+    source.send()
+    target = FileStore(str(tmpdir) + '-target')
+    target.recv(key)
+    assert b'value' == target[key]


### PR DESCRIPTION
Merging the FileStore and the Sync into a FileStore that can sync.
It has a local path and a remote url as parameters.

One store should be used for my own claims.
And a different store should be used for the claims of others.
We don't want to combine the two in the same local dir.
Otherwise we would start uploading other peoples claims.
If they use a different server
that would become an indirect sync between the servers.
I don't think we want that for now.

One thing that is interesting about what we are building here
is that the upload will basically be a brute force upload-it-all.
However the retrieval will always start from a specific key.
Then the content of that claim will be processed
and maybe we need to get some more nodes afterwards.

That's also what made me think about a tighter integration
between FileStore and Sync.
Because the claimchain is build on top of a store
which receives all the read calls.
We will have to delegate those to the sync then.